### PR TITLE
[Jamie] Text 컴포넌트 수정

### DIFF
--- a/packages/playground-react/pages/index.tsx
+++ b/packages/playground-react/pages/index.tsx
@@ -30,7 +30,9 @@ export const Examples = ({ examples }: ExampleProps) => (
         `}
       >
         {example.children ? (
-          <Text variant="articleTitle">{example.name}</Text>
+          <Text variant="articleTitle" sx={{ textTransform: 'capitalize' }}>
+            {example.name}
+          </Text>
         ) : (
           <Link href={example.path}>
             <Text sx={{ textDecoration: 'underline' }}>{example.name}</Text>

--- a/packages/react/src/components/Text/index.tsx
+++ b/packages/react/src/components/Text/index.tsx
@@ -14,6 +14,8 @@ export type TextSX = {
   lineHeight?: keyof typeof fonts.lineHeight;
   letterSpacing?: keyof typeof fonts.letterSpacing;
   textAlign?: keyof typeof fonts.textAlign;
+  textDecoration?: keyof typeof fonts.textDecoration;
+  textTransform?: keyof typeof fonts.textTransform;
 };
 
 const getCustomStyle = (sx: TextSX, theme: DefaultTheme) =>

--- a/packages/react/src/styles/fonts.ts
+++ b/packages/react/src/styles/fonts.ts
@@ -7,22 +7,13 @@ const fonts = {
     large: '2rem',
     xLarge: '2.2rem',
     xxLarge: '3.3rem',
-    inherit: 'inherit',
   },
   fontWeight: {
     regular: 400,
     bold: 700,
-    inherit: 'inherit',
   },
   fontFamily: {
     base: "'Noto Sans KR', sans-serif",
-    inherit: 'inherit',
-  },
-  fontStyle: {
-    italic: 'italic',
-    oblique: 'oblique',
-    normal: 'normal',
-    inherit: 'inherit',
   },
   lineHeight: {
     reset: 1,
@@ -38,16 +29,10 @@ const fonts = {
     center: 'center',
   },
   textDecoration: {
-    lineThrough: 'line-through',
-    overline: 'overline',
     underline: 'underline',
-    none: 'none'
   },
   textTransform: {
     capitalize: 'capitalize',
-    uppercase: 'uppercase',
-    lowercase: 'lowercase',
-    inherit: 'inherit',
   },
 };
 

--- a/packages/react/src/styles/fonts.ts
+++ b/packages/react/src/styles/fonts.ts
@@ -38,14 +38,16 @@ const fonts = {
     center: 'center',
   },
   textDecoration: {
-    dashed: 'dashed',
-    dotted: 'dotted',
-    double: 'double',
     lineThrough: 'line-through',
     overline: 'overline',
-    solid: 'solid',
     underline: 'underline',
-    wavy: 'wavy',
+    none: 'none'
+  },
+  textTransform: {
+    capitalize: 'capitalize',
+    uppercase: 'uppercase',
+    lowercase: 'lowercase',
+    inherit: 'inherit',
   },
 };
 


### PR DESCRIPTION
close #1 

Text 컴포넌트를 사용하다가 텍스트에 밑줄을 넣거나 대문자로 만드는 등 추가적인 속성이 필요해져서 추가해봤습니다!

**text-decoration**
wavy, dotted 등은 overline이나 underline 등 다른 속성과 조합해서 사용해야하기 때문에 모든 케이스를 다 작성할 수 없을 것 같아 단독으로 사용할 수 있는 line-through, overline, underline만 추가해주었습니다. 추가로 이미 적용된 스타일을 제거하기 위한 none도 넣었습니다.

**text-transform**
capitalize, uppercase, lowercase, inherit을 추가했습니다.