### PR TITLE
[Hemdi] FlexBox gap rem 단위, 속성 추가

### DIFF
--- a/packages/react/src/components/FlexBox/index.tsx
+++ b/packages/react/src/components/FlexBox/index.tsx
@@ -34,6 +34,9 @@ export interface FlexBoxSX extends SizeSX, SpacingSX, StyleSX {
     | 'space-evenly';
   alignItems?: 'center' | 'flex-start' | 'flex-end';
   flexDirection?: 'row' | 'column';
+  flexWrap?: 'nowrap' | 'wrap' | 'wrap-reverse';
+  flexShrink?: number;
+  flexGrow?: number;
   gap?: SpacingValue;
 }
 
@@ -67,8 +70,7 @@ const getFlexCssProperties = (sx: FlexBoxSX, theme: DefaultTheme) =>
     }
   }, {});
 
-const FlexBox = (props: FlexBoxProps) => {
-  const { sx, as = 'div', children } = props;
+const FlexBox = ({ sx, as = 'div', children }: FlexBoxProps) => {
   const theme = useTheme();
   const css = sx && getFlexCssProperties(sx, theme);
   return (

--- a/packages/react/src/components/FlexBox/index.tsx
+++ b/packages/react/src/components/FlexBox/index.tsx
@@ -7,6 +7,7 @@ import {
   getSpacingCssProps,
   SpacingValue,
   isSpacingProp,
+  addSpacingUnit,
 } from '@styles/spacing';
 import { Palette } from '@styles/theme';
 
@@ -50,7 +51,15 @@ const getFlexCssProperties = (sx: FlexBoxSX, theme: DefaultTheme) =>
   Object.entries(sx).reduce((css, [key, value]) => {
     switch (true) {
       case key === 'bgColor':
-        return { ...css, backgroundColor: theme.palette[value] ?? colors[value] };
+        return {
+          ...css,
+          backgroundColor: theme.palette[value] ?? colors[value],
+        };
+      case key === 'gap':
+        return {
+          ...css,
+          gap: addSpacingUnit(value),
+        };
       case isSpacingProp(key):
         return { ...css, ...getSpacingCssProps(key, value) };
       default:

--- a/packages/react/src/styles/spacing.ts
+++ b/packages/react/src/styles/spacing.ts
@@ -31,9 +31,9 @@ export const isSpacingProp = (key) =>
 export const getSpacingCssProps = (key: string, value: SpacingValue) => {
   if (typeof value !== 'string' && !spacing.includes(value)) return {};
 
-  const [propKey, dirKey] = key.split('');
+  const [propKey, directionKey] = key.split('');
   const property = properties[propKey];
-  const direction = directions?.[dirKey];
+  const direction = directions?.[directionKey];
 
   const spacingValue = typeof value === 'string' ? value : `${value}rem`;
 

--- a/packages/react/src/styles/spacing.ts
+++ b/packages/react/src/styles/spacing.ts
@@ -28,6 +28,9 @@ const directions = {
 export const isSpacingProp = (key) =>
   marginKeys.includes(key) || paddingKeys.includes(key);
 
+export const addSpacingUnit = (value) =>
+  typeof value === 'string' ? value : `${value}rem`;
+
 export const getSpacingCssProps = (key: string, value: SpacingValue) => {
   if (typeof value !== 'string' && !spacing.includes(value)) return {};
 
@@ -35,7 +38,7 @@ export const getSpacingCssProps = (key: string, value: SpacingValue) => {
   const property = properties[propKey];
   const direction = directions?.[directionKey];
 
-  const spacingValue = typeof value === 'string' ? value : `${value}rem`;
+  const spacingValue = addSpacingUnit(value);
 
   if (Array.isArray(direction)) {
     return direction.reduce(


### PR DESCRIPTION
close #10 

## ✨ 구현 내역
### 1. gap rem 단위 추가
```tsx
export interface FlexBoxSX extends SizeSX, SpacingSX, StyleSX {
   ...
  gap?: SpacingValue;
}

const getFlexCssProperties = (sx: FlexBoxSX, theme: DefaultTheme) =>
  Object.entries(sx).reduce((css, [key, value]) => {
    switch (true) {
      case key === 'gap':
        return {
          ...css,
          gap: addSpacingUnit(value),  // typeof value === 'string' ? value : `${value}rem`
        };
      default:
        return { ...css, [key]: value };
    }
  }, {});
```
기존에 gap에다가 그냥 SpacingValue 타입 지정만 해놓고 단위를 추가해주는 로직을 구현해놓지 않아서 rem이 적용이 안되는 문제를 제이미께서 제보해주셨습니다! 그 부분을 sapcing.ts에 addSpacingUnit 이라는 함수를 구현해 추가했습니다.
함수로 굳이 적용한 이유는 gap이 현재 spacing의 type에 의존되어 있어서 추후에 spacing에 변화가 있을 때 유지보수하기 쉬울 것 같아서 함수로 분리해서 적용했습니다!

### 2. flex box 속성 추가
```tsx
export interface FlexBoxSX extends SizeSX, SpacingSX, StyleSX {
  ...
  flexWrap?: 'nowrap' | 'wrap' | 'wrap-reverse';
  flexShrink?: number;
  flexGrow?: number;
}
```
페이지 마크업을 하다가 FlexBox에 Wrap, Shrink, Grow 속성이 필요할 것 같아 추가하게 되었습니다.

그런데 하나 고민인건 shrink랑 grow는 Flex 아이템에 적용되는 속성인데 지금처럼 FlexBox에 추가해서 함께 써도 괜찮은가? 따로 FlexItem을 구분해야하나? 라는 고민이 드네요!