### PR TITLE
[Jamie] Text, Tab, AvatarGroup 수정

### DIFF
--- a/packages/primitives/src/components/Tab/index.tsx
+++ b/packages/primitives/src/components/Tab/index.tsx
@@ -6,6 +6,7 @@ import {
   useContext,
   Children,
   cloneElement,
+  MouseEvent,
   ReactNode,
   ReactElement,
 } from 'react';
@@ -58,7 +59,7 @@ const TabList = ({ children, ...restProps }: TabListProps) => (
 type TabPropsType = {
   tabId?: number;
   children: ReactNode;
-  onClick?: () => void;
+  onClick?: (event?: MouseEvent<HTMLButtonElement>) => void;
 };
 
 const Tab = ({
@@ -70,9 +71,9 @@ const Tab = ({
   const [activeIndex, setActiveIndex] = useTabContext();
   const isActive = activeIndex === tabId;
 
-  const handleTabClick = () => {
-    if (tabId !== undefined) setActiveIndex(tabId)
-    onClick();
+  const handleTabClick = (event?: MouseEvent<HTMLButtonElement>) => {
+    if (tabId !== undefined) setActiveIndex(tabId);
+    onClick(event);
   };
 
   return (

--- a/packages/primitives/src/components/Tab/index.tsx
+++ b/packages/primitives/src/components/Tab/index.tsx
@@ -58,13 +58,22 @@ const TabList = ({ children, ...restProps }: TabListProps) => (
 type TabPropsType = {
   tabId?: number;
   children: ReactNode;
+  onClick?: () => void;
 };
 
-const Tab = ({ tabId, children, ...restProps }: TabPropsType) => {
+const Tab = ({
+  tabId,
+  children,
+  onClick = () => {},
+  ...restProps
+}: TabPropsType) => {
   const [activeIndex, setActiveIndex] = useTabContext();
   const isActive = activeIndex === tabId;
 
-  const handleTabClick = () => tabId !== undefined && setActiveIndex(tabId);
+  const handleTabClick = () => {
+    if (tabId !== undefined) setActiveIndex(tabId)
+    onClick();
+  };
 
   return (
     <li {...restProps} data-selected={isActive}>

--- a/packages/react/src/components/AvatarGroup/index.tsx
+++ b/packages/react/src/components/AvatarGroup/index.tsx
@@ -9,6 +9,12 @@ type AvatarGroupProps = {
   max?: number;
   total?: number;
   flexAlign?: 'flex-start' | 'center' | 'flex-end';
+  spacing?: 'small' | 'large';
+};
+
+const SPACING_OPTIONS = {
+  small: '-1.5rem',
+  large: '-0.5rem',
 };
 
 const AvatarGroupAvatar = styled(Avatar)`
@@ -28,6 +34,7 @@ const AvatarGroup = (props: AvatarGroupProps) => {
     max = 5,
     total = Children.count(childrenProp),
     flexAlign = 'center',
+    spacing = 'small',
   } = props;
 
   const theme = useTheme();
@@ -61,7 +68,7 @@ const AvatarGroup = (props: AvatarGroupProps) => {
             sx: {
               ...child.props.sx,
               border: `2px solid ${theme.palette.bgColor}`,
-              ...(index === 0 ? {} : { marginLeft: '-1.5rem' }),
+              ...(index === 0 ? {} : { marginLeft: SPACING_OPTIONS[spacing] }),
             },
           });
         })}
@@ -76,7 +83,7 @@ const AvatarGroup = (props: AvatarGroupProps) => {
           sx: {
             ...child.props.sx,
             border: `2px solid ${theme.palette.bgColor}`,
-            ...(index === 0 ? {} : { marginLeft: '-0.5rem' }),
+            ...(index === 0 ? {} : { marginLeft: SPACING_OPTIONS[spacing] }),
           },
         }),
       )}

--- a/packages/react/src/components/AvatarGroup/index.tsx
+++ b/packages/react/src/components/AvatarGroup/index.tsx
@@ -16,6 +16,7 @@ const AvatarGroupAvatar = styled(Avatar)`
   background-color: ${colors.grey700};
   color: ${colors.white};
   margin-left: -0.5rem;
+
   &:first-child {
     margin-left: 0;
   }
@@ -60,7 +61,7 @@ const AvatarGroup = (props: AvatarGroupProps) => {
             sx: {
               ...child.props.sx,
               border: `2px solid ${theme.palette.bgColor}`,
-              ...(index === 0 ? {} : { marginLeft: '-0.5rem' }),
+              ...(index === 0 ? {} : { marginLeft: '-1.5rem' }),
             },
           });
         })}

--- a/packages/react/src/components/Tab/basicTab.tsx
+++ b/packages/react/src/components/Tab/basicTab.tsx
@@ -13,7 +13,7 @@ const StyledTab = styled(Tab)`
 
   * {
     font-size: 2.2rem;
-    color: #dfdfdf;
+    color: ${colors.grey200};
   }
 
   &[data-selected='true'] {

--- a/packages/react/src/components/Tab/basicTab.tsx
+++ b/packages/react/src/components/Tab/basicTab.tsx
@@ -1,28 +1,30 @@
 import { Tab } from '@cos-ui/primitives';
 import styled from 'styled-components';
 
+import colors from "@styles/colors";
+
 const StyledTabList = styled(Tab.List)`
   display: flex;
-  gap: 20px;
+  gap: 2rem;
 `;
 
 const StyledTab = styled(Tab)`
   cursor: pointer;
 
   * {
-    font-size: 22px;
+    font-size: 2.2rem;
     color: #dfdfdf;
   }
 
   &[data-selected='true'] {
     * {
-      color: #939393;
+      color: ${colors.grey600};
     }
   }
 `;
 
 const StyledTabPanel = styled(Tab.Panel)`
-  color: #939393;
+  color: ${colors.grey600};
 `;
 
 StyledTab.Group = Tab.Group;

--- a/packages/react/src/components/Tab/borderTab.tsx
+++ b/packages/react/src/components/Tab/borderTab.tsx
@@ -1,17 +1,19 @@
 import { Tab } from '@cos-ui/primitives';
 import styled from 'styled-components';
 
+import colors from "@styles/colors";
+
 const StyledTabGroup = styled(Tab.Group)`
   width: 100%;
 `;
 
 const StyledTabList = styled(Tab.List)`
   display: flex;
-  gap: 20px;
+  gap: 2rem;
   width: inherit;
-  height: 70px;
-  background-color: #f5f5f5;
-  padding: 0 45px;
+  height: 7rem;
+  padding: 0 4.5rem;
+  background-color: ${colors.grey100};
 `;
 
 const StyledActiveBar = styled.div`
@@ -20,32 +22,29 @@ const StyledActiveBar = styled.div`
   left: 0;
   width: inherit;
   height: 3px;
-  background-color: #007aff;
+  background-color: ${({ theme }) => theme.palette.primary};
 `;
 
 const StyledTabRoot = styled(Tab)`
-  position: relative;
   display: flex;
   align-items: center;
-  width: 100px;
-  height: 100%;
+  position: relative;
+  color: #dfdfdf;
+  font-size: 2.2rem;
+  font-weight: 700;
   cursor: pointer;
 
   & > * {
-    width: 100px;
+    width: 10rem;
     height: 100%;
-    color: #dfdfdf;
-    font-size: 22px;
   }
 
   &[data-selected='true'] {
-    & > * {
-      color: #000000;
-    }
+    color: ${({ theme }) => theme.palette.fontColor};
   }
 
   &:not([data-selected='true']) {
-    & div {
+    ${StyledActiveBar} {
       display: none;
     }
   }
@@ -54,10 +53,10 @@ const StyledTabRoot = styled(Tab)`
 const StyledTabPanel = styled(Tab.Panel)`
   width: inherit;
   min-height: 50vh;
-  background-color: #fff;
-  color: #000000;
-  font-size: 18px;
-  padding: 45px;
+  padding: 4.5rem;
+  background-color: ${colors.white};
+  color: ${({ theme }) => theme.palette.fontColor};
+  font-size: 1.8rem;
 `;
 
 const StyledTab = Object.assign(StyledTabRoot, {

--- a/packages/react/src/components/Tab/borderTab.tsx
+++ b/packages/react/src/components/Tab/borderTab.tsx
@@ -29,7 +29,7 @@ const StyledTabRoot = styled(Tab)`
   display: flex;
   align-items: center;
   position: relative;
-  color: #dfdfdf;
+  color: ${colors.grey200};
   font-size: 2.2rem;
   font-weight: 700;
   cursor: pointer;

--- a/packages/react/src/components/Text/index.tsx
+++ b/packages/react/src/components/Text/index.tsx
@@ -11,6 +11,7 @@ import { Palette } from '@styles/theme';
 import { typography } from '@styles/typography';
 
 export interface TextSX extends SpacingSX {
+  display?: keyof typeof fonts.display;
   fontSize?: keyof typeof fonts.fontSize;
   fontWeight?: keyof typeof fonts.fontWeight;
   fontFamily?: keyof typeof fonts.fontFamily;
@@ -20,6 +21,7 @@ export interface TextSX extends SpacingSX {
   textAlign?: keyof typeof fonts.textAlign;
   textDecoration?: keyof typeof fonts.textDecoration;
   textTransform?: keyof typeof fonts.textTransform;
+  wordBreak?: keyof typeof fonts.wordBreak;
 }
 
 const getCustomStyle = (sx: TextSX, theme: DefaultTheme) =>

--- a/packages/react/src/components/Text/index.tsx
+++ b/packages/react/src/components/Text/index.tsx
@@ -11,7 +11,7 @@ import { Palette } from '@styles/theme';
 import { typography } from '@styles/typography';
 
 export interface TextSX extends SpacingSX {
-  display?: keyof typeof fonts.display;
+  display?: 'block' | 'inline-block' | 'inline';
   fontSize?: keyof typeof fonts.fontSize;
   fontWeight?: keyof typeof fonts.fontWeight;
   fontFamily?: keyof typeof fonts.fontFamily;

--- a/packages/react/src/styles/fonts.ts
+++ b/packages/react/src/styles/fonts.ts
@@ -1,9 +1,4 @@
 const fonts = {
-  display: {
-    block: 'block',
-    inlineBlock: 'inline-block',
-    inline: 'inline',
-  },
   fontSize: {
     xSmall: '1.2rem',
     small: '1.4rem',

--- a/packages/react/src/styles/fonts.ts
+++ b/packages/react/src/styles/fonts.ts
@@ -1,4 +1,9 @@
 const fonts = {
+  display: {
+    block: 'block',
+    inlineBlock: 'inline-block',
+    inline: 'inline',
+  },
   fontSize: {
     xSmall: '1.2rem',
     small: '1.4rem',
@@ -33,6 +38,9 @@ const fonts = {
   },
   textTransform: {
     capitalize: 'capitalize',
+  },
+  wordBreak: {
+    keepAll: 'keepAll',
   },
 };
 


### PR DESCRIPTION
close #14 

레이아웃 작성 중 필요하다고 생각됐던 스타일과 속성들을 추가해봤습니다!

### AvatarGroup
<div>
  <img width="130" alt="변경 전" src="https://user-images.githubusercontent.com/62706988/204994286-5c9c72b6-787e-4c43-ae35-6e84a132f910.png">
  <img width="100" alt="변경 후" src="https://user-images.githubusercontent.com/62706988/204994277-b0d68df2-9372-4d13-9cfc-2af146c6ebd2.png">
</div>

현재 AvatarGroup에서 아바타 간 간격이 좀 넓은 것 같다고 생각되어 margin을 좀 줄여주었습니다.

### Text

display 속성과 wordBreak 속성을 추가했습니다. display 속성은 태그를 inline block으로 변경한다던가 하는 경우가 있었고, wordBreack도 화면 사이즈가 줄어들었을 때 텍스트가 단어 형태로 유지되도록 하기 위해 추가하였습니다. Text 컴포넌트에 속성이 점점 많아지고 있는 것 같아 괜찮은 건가 싶네요 ^_ㅠ

### Tab

스터디 상세 페이지에서 탭을 선택함에 따라 URL이 변경되도록 구현하기 위해 클릭했을 때 어떤 동작을 할지를 추가적으로 넘겨줄 수 있는 onClick 속성을 추가했습니다. 아예 링크로 변경한 후 href 속성을 넘겨주면 내부에서 처리를 해주도록 구현하고 싶었으나 이 부분을 수행하려면 react-router-dom을 디펜던시로 추가해주어야 하기도 하고, next에서 사용하는 경우 라우팅을 react-router-dom을 사용해서 하고 있는 것 같지 않아 일단은 보류해두었습니다. 나중에 시간이 된다면 좀 더 찾아보고 보완해볼 계획입니다.


