### PR TITLE
[Park] exclude unnecessary files on publish

### DIFF
--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -9,6 +9,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc && tsc-alias && babel --root-mode upward --extensions .ts,.tsx src --out-dir dist",
     "watch": "tsc && tsc-alias && babel --root-mode upward --watch --extensions .ts,.tsx src --out-dir dist",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -9,6 +9,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc && tsc-alias && babel --root-mode upward --extensions .ts,.tsx src --out-dir dist",
     "watch": "tsc && tsc-alias && babel --root-mode upward --watch --extensions .ts,.tsx src --out-dir dist",


### PR DESCRIPTION
close #20 

현재 npm 에 배포된 파일 목록을 보면 사용할 때 불필요한 파일들도 포함되어있습니다. (자세한 내용은 #20)
이를 제거하기 위해 package.json 에 files 를 활용하였습니다, 

### Reference

https://stackoverflow.com/questions/31642477/how-can-i-publish-an-npm-package-with-distribution-files