### PR TITLE
[Hemdi] Spacing Value 변경

### DIFF
--- a/packages/playground-react/pages/avatar/avatar.tsx
+++ b/packages/playground-react/pages/avatar/avatar.tsx
@@ -20,7 +20,7 @@ const dummyAvatarsFour = new Array(1000)
 
 const AvatarPage = () => (
   <>
-    <FlexBox sx={{ flexDirection: 'column', gap: 1, mb: 2 }}>
+    <FlexBox sx={{ flexDirection: 'column', gap: 5, mb: 10 }}>
       <Text variant="sectionTitle">Avatar</Text>
       <Avatar src={AVATARS[0].src} alt={AVATARS[0].name} size="small" />
       <Avatar src={AVATARS[0].src} alt={AVATARS[0].name} />

--- a/packages/playground-react/pages/button/button.tsx
+++ b/packages/playground-react/pages/button/button.tsx
@@ -9,7 +9,7 @@ const ButtonPage = () => (
     `}
   >
     <Text variant="sectionTitle">Basic Button</Text>
-    <FlexBox sx={{ gap: '1rem', mt: 1, mb: 2 }}>
+    <FlexBox sx={{ gap: 5, mt: 5, mb: 10 }}>
       <Button>Button</Button>
       <Button disabled>Button</Button>
       <Button color="danger">Button</Button>
@@ -17,7 +17,7 @@ const ButtonPage = () => (
       <Button color="black">Button</Button>
     </FlexBox>
     <Text variant="sectionTitle">Outlined Button</Text>
-    <FlexBox sx={{ gap: '1rem', mt: 1, mb: 2 }}>
+    <FlexBox sx={{ gap: 5, mt: 5, mb: 10 }}>
       <Button variant="outlined">Button</Button>
       <Button variant="outlined" disabled>
         Button
@@ -33,7 +33,7 @@ const ButtonPage = () => (
       </Button>
     </FlexBox>
     <Text variant="sectionTitle">Round Button</Text>
-    <FlexBox sx={{ gap: '1rem', mt: 1, mb: 2 }}>
+    <FlexBox sx={{ gap: 5, mt: 5, mb: 10 }}>
       <Button shape="round">Button</Button>
       <Button shape="round" color="danger">
         Button
@@ -46,7 +46,7 @@ const ButtonPage = () => (
       </Button>
     </FlexBox>
     <Text variant="sectionTitle">Button Size</Text>
-    <FlexBox sx={{ gap: '1rem', mt: 1, mb: 2 }}>
+    <FlexBox sx={{ gap: 5, mt: 5, mb: 10 }}>
       <Button size="small">Button</Button>
       <Button size="medium">Button</Button>
       <Button size="large">Button</Button>

--- a/packages/playground-react/pages/radio/radio-with-form.tsx
+++ b/packages/playground-react/pages/radio/radio-with-form.tsx
@@ -12,7 +12,7 @@ export const FormRadioPage = () => {
       sx={{
         flexDirection: 'column',
         width: '100%',
-        gap: '1rem',
+        gap: 5,
       }}
     >
       <Form onSubmit={handleSubmit} validationMode="onBlur">
@@ -20,7 +20,7 @@ export const FormRadioPage = () => {
           sx={{
             flexDirection: 'column',
             width: '100%',
-            gap: '1rem',
+            gap: 5,
           }}
         >
           <Text
@@ -46,7 +46,7 @@ export const FormRadioPage = () => {
           스터디 생성
         </Button>
       </Form>
-      <FlexBox sx={{ flexDirection: 'column', gap: '1rem' }}>
+      <FlexBox sx={{ flexDirection: 'column', gap: 5 }}>
         {Object.keys(formValues).map((key) => (
           <Text key={key}>{`${key} : ${formValues[key]}`}</Text>
         ))}

--- a/packages/playground-react/pages/table/column-table.tsx
+++ b/packages/playground-react/pages/table/column-table.tsx
@@ -25,7 +25,7 @@ const ColumnTablePage = () => (
       </ColumnTable.HeadCell>
       <ColumnTable.HeadCell name="writer">
         <FlexBox
-          sx={{ justifyContent: 'center', alignItems: 'center', gap: '1rem' }}
+          sx={{ justifyContent: 'center', alignItems: 'center', gap: 5 }}
         >
           작성자
           <SortingIcon />
@@ -33,7 +33,7 @@ const ColumnTablePage = () => (
       </ColumnTable.HeadCell>
       <ColumnTable.HeadCell name="date">
         <FlexBox
-          sx={{ justifyContent: 'center', alignItems: 'center', gap: '1rem' }}
+          sx={{ justifyContent: 'center', alignItems: 'center', gap: 5 }}
         >
           날짜
           <SortingIcon />
@@ -41,7 +41,7 @@ const ColumnTablePage = () => (
       </ColumnTable.HeadCell>
       <ColumnTable.HeadCell name="view">
         <FlexBox
-          sx={{ justifyContent: 'center', alignItems: 'center', gap: '1rem' }}
+          sx={{ justifyContent: 'center', alignItems: 'center', gap: 5 }}
         >
           조회수
           <SortingIcon />

--- a/packages/playground-react/pages/table/row-table.tsx
+++ b/packages/playground-react/pages/table/row-table.tsx
@@ -35,7 +35,7 @@ const RowTablePage = () => (
     <RowTable.Row>
       <RowTable.HeadCell name="writer">
         <FlexBox
-          sx={{ justifyContent: 'center', alignItems: 'center', gap: '1rem' }}
+          sx={{ justifyContent: 'center', alignItems: 'center', gap: 5 }}
         >
           작성자
           <SortingIcon />
@@ -50,7 +50,7 @@ const RowTablePage = () => (
     <RowTable.Row>
       <RowTable.HeadCell name="date">
         <FlexBox
-          sx={{ justifyContent: 'center', alignItems: 'center', gap: '1rem' }}
+          sx={{ justifyContent: 'center', alignItems: 'center', gap: 5 }}
         >
           날짜
           <SortingIcon />
@@ -65,7 +65,7 @@ const RowTablePage = () => (
     <RowTable.Row>
       <RowTable.HeadCell name="view">
         <FlexBox
-          sx={{ justifyContent: 'center', alignItems: 'center', gap: '1rem' }}
+          sx={{ justifyContent: 'center', alignItems: 'center', gap: 5 }}
         >
           조회수
           <SortingIcon />

--- a/packages/playground-react/pages/text/text.tsx
+++ b/packages/playground-react/pages/text/text.tsx
@@ -1,35 +1,34 @@
 import { Text } from '@cos-ui/react';
 
 const TextPage = () => (
-    <div>
-      <Text variant="sectionTitle" sx={{ mb: '0.5rem' }}>Section Title</Text>
-      <Text variant="sectionDescription">
-        Section Description
+  <div>
+    <Text variant="sectionTitle" sx={{ mb: 2 }}>
+      Section Title
+    </Text>
+    <Text variant="sectionDescription">Section Description</Text>
+    <Text variant="articleTitle">Article Title</Text>
+    <Text variant="articleDescription">Article Description</Text>
+    <Text
+      variant="sectionDescription"
+      sx={{
+        fontSize: 'large',
+        fontWeight: 'bold',
+        color: 'primary',
+      }}
+    >
+      Section Description
+      <Text.Highlight sx={{ color: 'warning' }}> Highlight</Text.Highlight>
+    </Text>
+    <div css={{ width: '200px' }}>
+      <Text as="p" ellipsis>
+        A falsis, equiso barbatus abaculus.
       </Text>
-      <Text variant="articleTitle">Article Title</Text>
-      <Text variant="articleDescription">Article Description</Text>
-      <Text
-        variant="sectionDescription"
-        sx={{
-          fontSize: 'large',
-          fontWeight: 'bold',
-          color: 'primary',
-        }}
-      >
-        Section Description
-        <Text.Highlight sx={{ color: 'warning' }}> Highlight</Text.Highlight>
+      <Text as="p" ellipsis={2}>
+        Ubi est fidelis galatae? Velox cacula rare perderes bursa est. Heuretess
+        sunt bullas de neuter mensa. Brevis barcas foris desideriums musa est.
       </Text>
-      <div css={{ width: '200px' }}>
-        <Text as="p" ellipsis>
-          A falsis, equiso barbatus abaculus.
-        </Text>
-        <Text as="p" ellipsis={2}>
-          Ubi est fidelis galatae?
-          Velox cacula rare perderes bursa est. Heuretess sunt bullas de neuter mensa.
-          Brevis barcas foris desideriums musa est.
-        </Text>
-      </div>
     </div>
-  )
+  </div>
+);
 
 export default TextPage;

--- a/packages/react/src/components/AvatarGroup/avatarGroup.tsx
+++ b/packages/react/src/components/AvatarGroup/avatarGroup.tsx
@@ -2,7 +2,7 @@ import { Children, cloneElement, ReactElement, ReactNode } from 'react';
 import styled, { useTheme } from 'styled-components';
 
 import Avatar, { AvatarProps } from '@components/Avatar/avatar';
-import FlexBox from '@components/FlexBox';
+import { FlexBox } from '@components/FlexBox';
 
 type AvatarGroupProps = {
   children: ReactNode;

--- a/packages/react/src/components/FlexBox/flexBox.tsx
+++ b/packages/react/src/components/FlexBox/flexBox.tsx
@@ -12,7 +12,7 @@ import {
   getSpacingCssProps,
   SpacingValue,
   isSpacingProp,
-  addSpacingUnit,
+  getSpacingValue,
 } from '@styles/spacing';
 import { Palette } from '@styles/theme';
 
@@ -71,7 +71,7 @@ const getFlexCssProperties = (sx: FlexBoxSX, theme: DefaultTheme) =>
       case key === 'gap':
         return {
           ...css,
-          gap: addSpacingUnit(value),
+          gap: getSpacingValue(value),
         };
       case isSpacingProp(key):
         return { ...css, ...getSpacingCssProps(key, value) };

--- a/packages/react/src/styles/spacing.ts
+++ b/packages/react/src/styles/spacing.ts
@@ -1,13 +1,18 @@
 export type MarginKey = typeof marginKeys[number];
 export type PaddingKey = typeof paddingKeys[number];
-export type SpacingValue = typeof spacing[number] | string;
+export type SpacingValue = number | string;
 
 export type Margin = Partial<Record<MarginKey, SpacingValue>>;
 export type Padding = Partial<Record<PaddingKey, SpacingValue>>;
 
 export interface SpacingSX extends Margin, Padding {}
 
-const spacing = [0.5, 1, 1.5, 2, 2.5] as const;
+const SPACING_VALUE_PER_UNIT = 0.2;
+const SPACING_UNIT = 'rem';
+
+const spacing = (value: number) =>
+  `${value * SPACING_VALUE_PER_UNIT}${SPACING_UNIT}`;
+
 const marginKeys = ['m', 'mt', 'mr', 'mb', 'ml', 'mx', 'my'] as const;
 const paddingKeys = ['p', 'pt', 'pr', 'pb', 'pl', 'px', 'py'] as const;
 
@@ -28,17 +33,15 @@ const directions = {
 export const isSpacingProp = (key) =>
   marginKeys.includes(key) || paddingKeys.includes(key);
 
-export const addSpacingUnit = (value) =>
-  typeof value === 'string' ? value : `${value}rem`;
+export const getSpacingValue = (value: SpacingValue) =>
+  typeof value === 'string' ? value : spacing(value);
 
 export const getSpacingCssProps = (key: string, value: SpacingValue) => {
-  if (typeof value !== 'string' && !spacing.includes(value)) return {};
-
   const [propKey, directionKey] = key.split('');
   const property = properties[propKey];
   const direction = directions?.[directionKey];
 
-  const spacingValue = addSpacingUnit(value);
+  const spacingValue = getSpacingValue(value);
 
   if (Array.isArray(direction)) {
     return direction.reduce(


### PR DESCRIPTION
close #29 

## ✨ 구현 내역
- 기존 0.5 단위로 제한하던 Spacing의 value 를 0.2 단위로 변경하였습니다.
- 또한 배열을 이용해 구현했던 SpacingValue의 범위 제한을 제거하고, SpacingValue 의 타입을 `number | string` 으로 변경하였습니다.
- 변경된 타입에 따라 타입별 용도를 아래와 같이 제한하여 사용합시다!
  - number : 0.2 간격으로 rem 단위의 값을 사용하고 싶을 때
  - string : rem이 아닌 다른 단위의 값을 사용하고 싶을 때

### ✔️ Usage
```tsx
// 이전
<FlexBox sx={{ gap: '1rem', mt: 1, mb: 2 }}> 

// 현재
<FlexBox sx={{ gap: 5, mt: 5, mb: 10 }}>
```
**적용결과**

<img width="156" alt="스크린샷 2022-12-14 오전 4 06 57" src="https://user-images.githubusercontent.com/34249911/207423154-4ba9288b-817b-44dd-a313-ecab670f0bd0.png">
