### PR TITLE
[Park] Intersect Listener 

### DIFF
--- a/packages/playground-react/pages/intersect-listener/intersect-listener.tsx
+++ b/packages/playground-react/pages/intersect-listener/intersect-listener.tsx
@@ -1,0 +1,55 @@
+import { IntersectListener } from '@cos-ui/primitives';
+import { FlexBox, Paper, Text } from '@cos-ui/react';
+import { useEffect, useState } from 'react';
+
+const Card = ({ number }) => (
+  <Paper
+    sx={{
+      display: 'flex',
+      width: '300px',
+      height: '400px',
+      justifyContent: 'center',
+      alignItems: 'center',
+    }}
+  >
+    <Text variant="body">hi {number}</Text>
+  </Paper>
+);
+
+const datas = [
+  [1, 2, 3, 4],
+  [5, 6, 7, 8],
+  [9, 10, 11, 12],
+  [13, 14, 15, 16],
+];
+
+const getData = (page: number) => datas[page];
+
+const IntersectListenerPage = () => {
+  const [page, setPage] = useState(0);
+  const [elements, setElements] = useState<number[]>(getData(0));
+
+  useEffect(() => {
+    if (page !== 0) {
+      setElements((prev) => [...prev, ...getData(page)]);
+    }
+  }, [page]);
+
+  return (
+    <IntersectListener
+      onIntersect={() => {
+        setPage((prev) => prev + 1);
+      }}
+      unobserve={page === 3}
+    >
+      <Text variant="sectionTitle">Intersect Listener</Text>
+      <FlexBox sx={{ width: '1240px', flexWrap: 'wrap', gap: '40px 10px' }}>
+        {elements.map((element) => (
+          <Card key={element} number={element} />
+        ))}
+      </FlexBox>
+    </IntersectListener>
+  );
+};
+
+export default IntersectListenerPage;

--- a/packages/primitives/src/components/IntersectListener/index.tsx
+++ b/packages/primitives/src/components/IntersectListener/index.tsx
@@ -1,0 +1,1 @@
+export { default as IntersectListener } from '@components/IntersectListener/intersectListener';

--- a/packages/primitives/src/components/IntersectListener/intersectListener.md
+++ b/packages/primitives/src/components/IntersectListener/intersectListener.md
@@ -1,0 +1,33 @@
+# Intersect Listener
+
+`IntersectListener` 컴포넌트는 페이지 가장 하단에 Intersection 을 감지하기 위한 엘리먼트가 존재하며,
+그 엘리먼트가 Intersect 되었을 때 `onIntersect` callback 을 실행합니다.
+
+Observer 가 unobserve 되기 위한 조건을 props 에 함께 넣어 사용합니다.
+
+## Props
+
+- `rootMargin` - root 가 가진 여백입니다. `default: 0px 0px 0px 0px`
+- `threshold` - observer의 콜백이 실행될 대상 요소의 가시성 퍼센티지입니다. (0~1) `default: 0.0`
+- `onIntersect` - 대상 요소가 가시성에 들어왔을 때 실행될 콜백입니다.
+- `unobserve` - observer를 해제할지 여부입니다. `default: false`
+
+## Usage
+
+```tsx
+const IntersectListenerPage = () => (
+  <IntersectListener
+    onIntersect={() => {
+      setPage((prev) => prev + 1);
+    }}
+    unobserve={page === 3}
+  >
+    <Text variant="sectionTitle">Intersect Listener</Text>
+    <FlexBox sx={{ width: '1240px', flexWrap: 'wrap', gap: '40px 10px' }}>
+      {elements.map((element) => (
+        <Card key={element} number={element} />
+      ))}
+    </FlexBox>
+  </IntersectListener>
+);
+```

--- a/packages/primitives/src/components/IntersectListener/intersectListener.tsx
+++ b/packages/primitives/src/components/IntersectListener/intersectListener.tsx
@@ -1,0 +1,68 @@
+import { ReactNode, useCallback, useEffect, useMemo, useRef } from 'react';
+
+type IntersectListenerProps = {
+  children: ReactNode;
+  onIntersect: (target?: HTMLElement) => void;
+  unobserve: boolean;
+  rootMargin?: string;
+  threshold?: number;
+};
+
+/**
+ *
+ * @name IntersectListener
+ * @description scroll 이벤트를 사용하지 않고, IntersectionObserver를 사용하여 대상 요소의 가시성을 감지합니다.
+ * @props rootMargin - root 가 가진 여백입니다. `default: 0px 0px 0px 0px`
+ * @props threshold - observer의 콜백이 실행될 대상 요소의 가시성 퍼센티지입니다. (0~1) `default: 0.0`
+ * @props onIntersect - 대상 요소가 가시성에 들어왔을 때 실행될 콜백입니다.
+ * @props unobserve - observer를 해제할지 여부입니다. `default: false`
+ */
+const IntersectListener = (props: IntersectListenerProps) => {
+  const {
+    children,
+    onIntersect,
+    unobserve = false,
+    rootMargin = '0px 0px 0px 0px',
+    threshold = 0,
+  } = props;
+  const ref = useRef<HTMLDivElement>(null);
+
+  const handleObserver = useCallback(
+    (entries: IntersectionObserverEntry[]) => {
+      const [entry] = entries;
+      if (entry.isIntersecting) {
+        onIntersect(entry.target as HTMLElement);
+      }
+    },
+    [onIntersect],
+  );
+
+  const observer = useMemo(
+    () =>
+      new IntersectionObserver(handleObserver, {
+        rootMargin,
+        threshold,
+      }),
+    [handleObserver, rootMargin, threshold],
+  );
+
+  useEffect(() => {
+    if (ref.current && !unobserve) {
+      observer.observe(ref.current);
+    } else if (ref.current && unobserve) {
+      observer.unobserve(ref.current);
+    }
+    return () => {
+      observer.disconnect();
+    };
+  }, [unobserve, observer]);
+
+  return (
+    <div>
+      {children}
+      <div ref={ref} />
+    </div>
+  );
+};
+
+export default IntersectListener;

--- a/packages/primitives/src/components/IntersectListener/intersectListener.tsx
+++ b/packages/primitives/src/components/IntersectListener/intersectListener.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useCallback, useEffect, useMemo, useRef } from 'react';
+import { ReactNode, useCallback, useEffect, useRef } from 'react';
 
 type IntersectListenerProps = {
   children: ReactNode;
@@ -26,6 +26,7 @@ const IntersectListener = (props: IntersectListenerProps) => {
     threshold = 0,
   } = props;
   const ref = useRef<HTMLDivElement>(null);
+  const observer = useRef<IntersectionObserver>();
 
   const handleObserver = useCallback(
     (entries: IntersectionObserverEntry[]) => {
@@ -37,23 +38,23 @@ const IntersectListener = (props: IntersectListenerProps) => {
     [onIntersect],
   );
 
-  const observer = useMemo(
-    () =>
-      new IntersectionObserver(handleObserver, {
-        rootMargin,
-        threshold,
-      }),
-    [handleObserver, rootMargin, threshold],
-  );
+  useEffect(() => {
+    observer.current = new IntersectionObserver(handleObserver, {
+      rootMargin,
+      threshold,
+    });
+  }, []);
 
   useEffect(() => {
-    if (ref.current && !unobserve) {
-      observer.observe(ref.current);
-    } else if (ref.current && unobserve) {
-      observer.unobserve(ref.current);
+    if (ref.current && !unobserve && observer.current) {
+      observer.current.observe(ref.current);
+    } else if (ref.current && unobserve && observer.current) {
+      observer.current.unobserve(ref.current);
     }
     return () => {
-      observer.disconnect();
+      if (observer.current) {
+        observer.current.disconnect();
+      }
     };
   }, [unobserve, observer]);
 

--- a/packages/primitives/src/components/IntersectListener/intersectListener.tsx
+++ b/packages/primitives/src/components/IntersectListener/intersectListener.tsx
@@ -16,6 +16,19 @@ type IntersectListenerProps = {
  * @props threshold - observer의 콜백이 실행될 대상 요소의 가시성 퍼센티지입니다. (0~1) `default: 0.0`
  * @props onIntersect - 대상 요소가 가시성에 들어왔을 때 실행될 콜백입니다.
  * @props unobserve - observer를 해제할지 여부입니다. `default: false`
+ * @example
+ * ```tsx
+ *   <IntersectListener
+ *     onIntersect={() => setPage((prev) => prev + 1)}
+ *     unobserve={page === 3}
+ *   >
+ *     <FlexBox sx={{ width: '1240px', flexWrap: 'wrap', gap: '40px 10px' }}>
+ *       {elements.map((element) => (
+ *         <Card key={element} number={element} />
+ *       ))}
+ *     </FlexBox>
+ *   </IntersectListener>
+ * ```
  */
 const IntersectListener = (props: IntersectListenerProps) => {
   const {

--- a/packages/primitives/src/index.ts
+++ b/packages/primitives/src/index.ts
@@ -8,3 +8,4 @@ export { default as Radio } from '@components/Radio';
 export { default as Slider } from '@components/Slider';
 export { default as Tab } from '@components/Tab';
 export { ColumnTable, RowTable, BasicTable } from '@components/Table';
+export * from '@components/IntersectListener';

--- a/packages/react/src/components/AvatarGroup/avatarGroup.tsx
+++ b/packages/react/src/components/AvatarGroup/avatarGroup.tsx
@@ -2,7 +2,7 @@ import { Children, cloneElement, ReactElement, ReactNode } from 'react';
 import styled, { useTheme } from 'styled-components';
 
 import Avatar, { AvatarProps } from '@components/Avatar/avatar';
-import { FlexBox } from '@components/FlexBox';
+import FlexBox from '@components/FlexBox/flexBox';
 
 type AvatarGroupProps = {
   children: ReactNode;


### PR DESCRIPTION
close #33

Infinity Scroll 을 구현하기 위한 Intersect Listener 입니다.
한번 구현해보셨다면 어렵지 않게 로직 파악을 하실 수 있을텐데, 특이하다고 생각되는 몇 개만 설명하겠습니다

1. entries 가 아닌 entry 하나만 사용
  - 관찰하는 요소가 Intersect Listener 컴포넌트 안에 하나만 있어 entries 로 만들 필요가 있나? 라고 생각했습니다.
2. observer 를 useRef 로 선언
  - SSR 에서는 전역객체가 브라우저 환경과 달라 IntersectionObserver 메서드를 제대로 찾지 못하는 이슈가 있어 ([수정커밋](https://github.com/Co-Studo/cos-ui/commit/c8be3875bfb6253b39c3ce08bb20ff22cd19beac)) useEffect 내부에서 선언하여 사용해야 했습니다. 따라서 useRef 를 사용하였습니다. ( [reference](https://stackoverflow.com/a/59426367) ) 
3. md 로 컴포넌트를 설명하는 것에 추가하여 개발 환경에서도 `jsdoc` 을 활용하면 더 생산성이 좋아지겠다는 생각으로 도입해보았습니다.

