### PR TITLE
[Park] Flexbox import path 수정

### DIFF
--- a/packages/react/src/components/AvatarGroup/avatarGroup.tsx
+++ b/packages/react/src/components/AvatarGroup/avatarGroup.tsx
@@ -2,7 +2,7 @@ import { Children, cloneElement, ReactElement, ReactNode } from 'react';
 import styled, { useTheme } from 'styled-components';
 
 import Avatar, { AvatarProps } from '@components/Avatar/avatar';
-import FlexBox from '@components/FlexBox';
+import FlexBox from '@components/FlexBox/flexBox';
 
 type AvatarGroupProps = {
   children: ReactNode;


### PR DESCRIPTION
도니 PR 이 netlify 배포실패가 되어서 빌드 에러가 왜 발생했는지 찾아보았고 수정했습니다.

<img width="1072" alt="스크린샷 2023-01-09 오후 7 55 06" src="https://user-images.githubusercontent.com/58503584/211292237-f497dda0-dec6-476d-978e-2571daccb6c7.png">


두 개의 PR 이 한번에 merge 되면서
이전 merge 를 기반으로 rebase 하는 과정을 거치지 않아 husky 가 걸러내지 못했던 에러입니다

PR merge 를 rebase 된 것을 기반으로 하게 강제해야할까요?
