### PR TITLE
[Park] Clickable Paper + Flexbox

### DIFF
--- a/packages/playground-react/pages/intersect-listener/intersect-listener.tsx
+++ b/packages/playground-react/pages/intersect-listener/intersect-listener.tsx
@@ -5,7 +5,6 @@ import { useEffect, useState } from 'react';
 const Card = ({ number }) => (
   <Paper
     sx={{
-      display: 'flex',
       width: '300px',
       height: '400px',
       justifyContent: 'center',

--- a/packages/playground-react/pages/paper/paper.tsx
+++ b/packages/playground-react/pages/paper/paper.tsx
@@ -1,9 +1,25 @@
-import { Text, Paper } from '@cos-ui/react';
+import { Text, Paper, FlexBox } from '@cos-ui/react';
 
 const PaperPage = () => (
-  <Paper>
-    <Text>Paper</Text>
-  </Paper>
+  <FlexBox sx={{ flexDirection: 'column', gap: 10 }}>
+    <Text variant="sectionTitle">Paper</Text>
+    <Paper>
+      <Text>Paper</Text>
+    </Paper>
+    <Text variant="sectionTitle">Clickable Paper</Text>
+    <Paper
+      onClick={() => {
+        console.log('clicked');
+      }}
+      sx={{
+        gap: 2,
+      }}
+    >
+      <Text>Clickable Paper</Text>
+      <Text>Clickable Paper</Text>
+      <Text>Clickable Paper</Text>
+    </Paper>
+  </FlexBox>
 );
 
 export default PaperPage;

--- a/packages/react/src/components/Paper/index.tsx
+++ b/packages/react/src/components/Paper/index.tsx
@@ -1,19 +1,30 @@
 import { ReactNode, MouseEvent } from 'react';
 import { useTheme } from 'styled-components';
 
-import { SpacingSX } from '@styles/spacing';
+import FlexBox, { FlexBoxSX } from '@components/FlexBox/flexBox';
 
-interface PaperSX extends SpacingSX {
-  width?: string;
-  height?: string;
+type BasePaperSX = {
   borderRadius?: string;
   boxShadow?: string;
-}
+};
 
-type PaperProps = {
+const isBasePaperProp = (prop: string): prop is keyof BasePaperSX =>
+  ['borderRadius', 'boxShadow'].includes(prop);
+
+interface FlexPaperSX extends FlexBoxSX, BasePaperSX {}
+
+type PaperProps = FlexPaperProps;
+
+type BasePaperProps = {
   children: ReactNode;
   onClick?: (e: MouseEvent) => void;
-  sx?: PaperSX;
+  sx?: BasePaperSX;
+};
+
+type FlexPaperProps = {
+  children: ReactNode;
+  onClick?: (e: MouseEvent) => void;
+  sx?: FlexPaperSX;
 };
 
 const clickableCss = {
@@ -25,7 +36,7 @@ const clickableCss = {
   },
 };
 
-const Paper = (props: PaperProps) => {
+const BasePaper = (props: BasePaperProps) => {
   const { children, onClick, sx } = props;
   const theme = useTheme();
 
@@ -49,6 +60,60 @@ const Paper = (props: PaperProps) => {
       {children}
     </div>
   );
+};
+
+const FlexPaper = (props: FlexPaperProps) => {
+  const { children, onClick, sx = {} } = props;
+  const theme = useTheme();
+
+  const paperCss = {
+    width: 'max-content',
+    padding: '1rem',
+    borderRadius: '0.5rem',
+    boxShadow: `0 4px 10px ${theme.palette.shadow_100},
+    0 0 4px ${theme.palette.shadow_500}`,
+  };
+
+  const paperSX = Object.entries(sx).reduce((css, [key, value]) => {
+    if (isBasePaperProp(key)) {
+      return {
+        ...css,
+        [key]: value,
+      };
+    }
+    return css;
+  }, {});
+
+  const flexSX = Object.entries(sx).reduce((css, [key, value]) => {
+    if (!isBasePaperProp(key)) {
+      return {
+        ...css,
+        [key]: value,
+      };
+    }
+    return css;
+  }, {});
+
+  return (
+    <div
+      onClick={onClick}
+      css={{
+        ...paperCss,
+        ...(onClick && clickableCss),
+        ...paperSX,
+      }}
+    >
+      <FlexBox sx={flexSX}>{children}</FlexBox>
+    </div>
+  );
+};
+
+const Paper = (props: PaperProps) => {
+  const { sx = {} } = props;
+
+  const isFlex = Object.keys(sx).some((key) => !isBasePaperProp(key));
+
+  return isFlex ? <FlexPaper {...props} /> : <BasePaper {...props} />;
 };
 
 export default Paper;

--- a/packages/react/src/components/Paper/index.tsx
+++ b/packages/react/src/components/Paper/index.tsx
@@ -1,21 +1,48 @@
-import { ReactNode } from 'react';
-import { CSSObject, useTheme } from 'styled-components';
+import { ReactNode, MouseEvent } from 'react';
+import { useTheme } from 'styled-components';
+
+import { SpacingSX } from '@styles/spacing';
+
+interface PaperSX extends SpacingSX {
+  width?: string;
+  height?: string;
+  borderRadius?: string;
+  boxShadow?: string;
+}
 
 type PaperProps = {
   children: ReactNode;
-  sx?: CSSObject;
+  onClick?: (e: MouseEvent) => void;
+  sx?: PaperSX;
 };
 
-const Paper = ({ children, sx }: PaperProps) => {
+const clickableCss = {
+  cursor: 'pointer',
+  margin: '0.5rem',
+  transition: 'transform 0.1s ease-in-out',
+  ':hover': {
+    transform: 'scale(1.05)',
+  },
+};
+
+const Paper = (props: PaperProps) => {
+  const { children, onClick, sx } = props;
   const theme = useTheme();
+
+  const paperCss = {
+    width: 'max-content',
+    padding: '1rem',
+    borderRadius: '0.5rem',
+    boxShadow: `0 4px 10px ${theme.palette.shadow_100},
+    0 0 4px ${theme.palette.shadow_500}`,
+  };
+
   return (
     <div
+      onClick={onClick}
       css={{
-        width: 'max-content',
-        padding: '1rem',
-        borderRadius: '0.5rem',
-        boxShadow: `0 4px 10px ${theme.palette.shadow_100},
-        0 0 4px ${theme.palette.shadow_500}`,
+        ...paperCss,
+        ...(onClick && clickableCss),
         ...sx,
       }}
     >

--- a/packages/react/src/components/Paper/index.tsx
+++ b/packages/react/src/components/Paper/index.tsx
@@ -108,6 +108,27 @@ const FlexPaper = (props: FlexPaperProps) => {
   );
 };
 
+/**
+ *
+ * @name Paper
+ * @description `border-radius` 와 `box-shadow` 를 가진 Container 컴포넌트입니다.
+ * @props sx - `Paper` 의 스타일을 정의하는 객체입니다. `FlexBox` 의 `sx` 를 사용하면 `FlexBox` 가 적용됩니다.
+ * @props onClick - `onClick` 이벤트를 받으면 Clickable CSS가 적용됩니다.
+ * @example
+ * ```tsx
+ *   <Paper
+ *     onClick={() => {...}}
+ *     sx={{
+ *       borderRadius: '1rem',
+ *       gap: 2,
+ *     }}
+ *   >
+ *     <Text>Clickable Paper</Text>
+ *     <Text>Clickable Paper</Text>
+ *     <Text>Clickable Paper</Text>
+ *   </Paper>
+ * ```
+ */
 const Paper = (props: PaperProps) => {
   const { sx = {} } = props;
 

--- a/packages/react/src/components/Paper/paper.md
+++ b/packages/react/src/components/Paper/paper.md
@@ -1,0 +1,46 @@
+# Paper
+
+`border-radius` 와 `box-shadow` 를 가진 Container 컴포넌트입니다.
+`sx` prop 을 통해 `border-radius`, `box-shadow` 를 수정할 수 있으며 `FlexBox` 의 `sx` 를 사용하면 `FlexBox` 가 적용됩니다.
+`onClick` 이벤트를 받으면 `Cursor` 가 `Pointer` 로 변경되고, hover css (transform scale) 가 적용됩니다.
+
+### SX
+
+```tsx
+type BasePaperSX = {
+  borderRadius?: string;
+  boxShadow?: string;
+};
+
+interface FlexPaperSX extends FlexBoxSX, BasePaperSX {}
+
+type BasePaperProps = {
+  children: ReactNode;
+  onClick?: (e: MouseEvent) => void;
+  sx?: BasePaperSX;
+};
+
+type FlexPaperProps = {
+  children: ReactNode;
+  onClick?: (e: MouseEvent) => void;
+  sx?: FlexPaperSX;
+};
+
+type PaperProps = FlexPaperProps;
+```
+
+### Usage
+
+```tsx
+  <Paper
+    onClick={() => {...}}
+    sx={{
+      borderRadius: '1rem',
+      gap: 2,
+    }}
+  >
+    <Text>Clickable Paper</Text>
+    <Text>Clickable Paper</Text>
+    <Text>Clickable Paper</Text>
+  </Paper>
+```


### PR DESCRIPTION
close #40

Paper 가 필요에 따라 Click 이 가능하길 바랄 수 있고, 프로젝트에서 그런 상황이 발생하여 onClick prop 을 추가하였고, click 여부를 확인할 수 있도록 cursor 와 hover 관련 css 를 추가하였습니다.

또한 Paper 와 FlexBox 를 중첩으로 사용해야하는 번거로움이 있었는데, 이를 isFlex 등의 prop 을 받아서 처리할까 고민하다가 sx 로 FlexBoxSX 관련 prop 을 받으면 FlexBox 를 적용시키는 방향으로 진행해보았습니다. 혹시 isFlex 같은 prop 을 명시적으로 넘겨주는 방식이 더 좋을 것 같은지 의견 있으시면 남겨주시면 감사하겠습니다.


