### PR TITLE
[Park] Avatar Size 지정 방법 추가

### DIFF
--- a/packages/playground-react/pages/avatar/avatar.tsx
+++ b/packages/playground-react/pages/avatar/avatar.tsx
@@ -25,6 +25,11 @@ const AvatarPage = () => (
       <Avatar src={AVATARS[0].src} alt={AVATARS[0].name} size="small" />
       <Avatar src={AVATARS[0].src} alt={AVATARS[0].name} />
       <Avatar src={AVATARS[0].src} alt={AVATARS[0].name} size="large" />
+      <Avatar
+        src={AVATARS[0].src}
+        alt={AVATARS[0].name}
+        sx={{ width: '10rem', height: '10rem' }}
+      />
       <Avatar sx={{ backgroundColor: 'primary' }} size="small">
         박
       </Avatar>

--- a/packages/react/src/components/Avatar/avatar.tsx
+++ b/packages/react/src/components/Avatar/avatar.tsx
@@ -1,12 +1,13 @@
 import { useTheme } from 'styled-components';
 
 import Text from '@components/Text';
+import { SizeSX } from '@styles/size';
 import { SpacingSX } from '@styles/spacing';
 import { Palette } from '@styles/theme';
 
 type AvatarSize = 'small' | 'medium' | 'large';
 
-interface AvatarSX extends SpacingSX {
+interface AvatarSX extends SpacingSX, SizeSX {
   border?: string;
   borderRadius?: string;
   backgroundColor?: keyof Palette;
@@ -68,6 +69,21 @@ const getSizeStyle = (size: AvatarSize) => {
   }
 };
 
+/**
+ *
+ * @name Avatar
+ * @description `src` 속성에 이미지를 넣는 경우 `size` 에 맞는 크기로 동그란 컴포넌트가 생성됩니다.
+만약 `src` 가 지정되지 않고, `children` 으로 문자열 을 사용하는 경우 글자수에 맞게 문자열 아바타가 생성됩니다.
+ * @props `src` : `Avatar` 에 적용할 이미지의 경로를 입력합니다.
+ * @props `alt` : 이미지의 텍스트 설명입니다.
+ * @props `size` : `small`, `medium`, `large` 중 선택할 수 있습니다. `default: medium`
+ * @props `sx` : `border`, `borderRadius`, `backgroundColor`, `color` 이외 `Spacing`, `Size` 관련 속성을 활용할 수 있습니다.
+ * @example
+ * ```tsx
+ *  <Avatar src={image.src} alt={image.name} size="large" />
+ *  <Avatar sx={{ backgroundColor: 'primary' }}>박상진</Avatar>
+ * ```
+ */
 const Avatar = (props: AvatarProps) => {
   const theme = useTheme();
   const { alt, src, sx = {}, size = 'medium', children, className } = props;

--- a/packages/react/src/components/FlexBox/flexBox.tsx
+++ b/packages/react/src/components/FlexBox/flexBox.tsx
@@ -7,6 +7,7 @@ import {
 } from 'react';
 import styled, { DefaultTheme, useTheme } from 'styled-components';
 
+import { SizeSX } from '@styles/size';
 import {
   SpacingSX,
   getSpacingCssProps,
@@ -15,15 +16,6 @@ import {
   getSpacingValue,
 } from '@styles/spacing';
 import { Palette } from '@styles/theme';
-
-export type SizeSX = {
-  width?: string;
-  maxWidth?: string;
-  minWidth?: string;
-  height?: string;
-  maxHeight?: string;
-  minHeight?: string;
-};
 
 export type StyleSX = {
   bgColor?: keyof Palette;

--- a/packages/react/src/styles/size.ts
+++ b/packages/react/src/styles/size.ts
@@ -1,0 +1,8 @@
+export type SizeSX = {
+  width?: string;
+  maxWidth?: string;
+  minWidth?: string;
+  height?: string;
+  maxHeight?: string;
+  minHeight?: string;
+};


### PR DESCRIPTION
close #45 

디자인 상 지정된 사이즈 이외에도 다양한 사이즈가 필요할 수밖에 없다고 생각이 들어 SizeSX 를 활용해 지정하는 방법을 추가했습니다.
디자인 상 지정된 사이즈를 사용하는 것은 편리함과 동시에 제한을 두어 강제하는 느낌도 있는데, 
Custom 하게 사용되는 사이즈가 동일한 사이즈로 (혹은 비슷한 사이즈로) 많은 곳에서 쓰이게 되면 그 때 지정된 사이즈를 추가 하는 방식이 맞다고 생각이 들었습니다. 
이에 대해 어떻게 생각하시는지도 궁금합니다.

(일단 해당 SX 를 추가한 이유는 User Detail 에 들어가는 Avatar 사이즈는 단 한 곳에서만 쓰이기 때문에 xxxLarge 등의 키워드로 추가하는 것이 되려 불편해보였습니다. xxxLarge 가 어디서 쓰이는 지 추적도 어렵고..)

SIzeSX 는 FlexBox 컴포넌트에 있길래 styles/size.ts 로 별도 분리하였습니다.