### PR TITLE
[Park] AvatarGroup 내부 로직 리팩토링 (cloneElement, Children 관련)

### DIFF
--- a/packages/react/src/components/AvatarGroup/avatarGroup.md
+++ b/packages/react/src/components/AvatarGroup/avatarGroup.md
@@ -1,6 +1,6 @@
 # AvatarGroup
 
-`AvatarGroup` 은 [`Avatar` 컴포넌트](https://github.com/Co-Studo/cos-ui/tree/dev/packages/react/src/components/Avatar/avatar.md)와 같이 쓰이는 컴포넌트 입니다.
+`AvatarGroup` 은 `avatars` 를 prop 으로 전달받아 [`Avatar` 컴포넌트](https://github.com/Co-Studo/cos-ui/tree/dev/packages/react/src/components/Avatar/avatar.md) 로 렌더링하는 컴포넌트 입니다.
 `max` prop 을 통해 `Avatar` 가 보여질 최대 갯수를 지정하여 만약 그 수가 넘을 경우 마지막 `Avatar` 에서 `아바타 갯수의 합` - `max` + `1` 만큼의 갯수가 보여집니다
 
 ex) 4 개의 아바타를 받았는데 최대 3개만 보여주고 싶은 경우 마지막 `Avatar` 는 `4` - `3` + `1` = `2` 을 표시합니다.
@@ -9,6 +9,7 @@ ex) 4 개의 아바타를 받았는데 최대 3개만 보여주고 싶은 경우
 
 - `max` : `Avatar` 가 보여질 최대 갯수를 지정합니다. `default: 5`
 - `spacing` : `Avatar` 간의 간격을 `small`, `medium`, `large` 중 선택할 수 있습니다. `default: small`
+- `size` : `Avatar` 들의 사이즈를 지정합니다. `default: small`
 
 ## Usage
 
@@ -16,16 +17,7 @@ ex) 4 개의 아바타를 받았는데 최대 3개만 보여주고 싶은 경우
 const AvatarPage = () => (
   <FlexBox sx={{ flexDirection: 'column', gap: 1 }}>
     <Text variant="sectionTitle">Avatar Group</Text>
-    <AvatarGroup max={3} spacing="small">
-      {AVATARS.slice(0, 2).map((avatar) => (
-        <Avatar
-          key={avatar.id}
-          src={avatar.src}
-          alt={avatar.name}
-          size="small"
-        />
-      ))}
-    </AvatarGroup>
+    <AvatarGroup max={3} spacing="small" avatars={AVATARS} />
   </FlexBox>
 );
 ```

--- a/packages/react/src/components/AvatarGroup/avatarGroup.md
+++ b/packages/react/src/components/AvatarGroup/avatarGroup.md
@@ -10,6 +10,7 @@ ex) 4 개의 아바타를 받았는데 최대 3개만 보여주고 싶은 경우
 - `max` : `Avatar` 가 보여질 최대 갯수를 지정합니다. `default: 5`
 - `spacing` : `Avatar` 간의 간격을 `small`, `medium`, `large` 중 선택할 수 있습니다. `default: small`
 - `size` : `Avatar` 들의 사이즈를 지정합니다. `default: small`
+- `avatars` : Avatar 의 정보를 담는 배열을 입력합니다. `ex) AvatarProps[]`
 
 ## Usage
 

--- a/packages/react/src/components/AvatarGroup/avatarGroup.stories.tsx
+++ b/packages/react/src/components/AvatarGroup/avatarGroup.stories.tsx
@@ -62,137 +62,67 @@ export const Default = () => (
   <>
     <FlexBox sx={{ flexDirection: 'column', gap: 1 }}>
       <Text variant="sectionTitle">Avatar Group - Small</Text>
-      <AvatarGroup max={3} spacing="small">
-        {AVATARS.slice(0, 2).map((avatar) => (
-          <Avatar
-            key={avatar.id}
-            src={avatar.src}
-            alt={avatar.name}
-            size="small"
-          />
-        ))}
-      </AvatarGroup>
-      <AvatarGroup max={3} spacing="small">
-        {AVATARS.map((avatar) => (
-          <Avatar
-            key={avatar.id}
-            src={avatar.src}
-            alt={avatar.name}
-            size="small"
-          />
-        ))}
-      </AvatarGroup>
-      <AvatarGroup max={3} spacing="small">
-        {AVATARS_GROUP.double.map((avatar) => (
-          <Avatar
-            key={avatar.id}
-            src={avatar.src}
-            alt={avatar.name}
-            size="small"
-          />
-        ))}
-      </AvatarGroup>
-      <AvatarGroup max={3} spacing="small">
-        {AVATARS_GROUP.triple.map((avatar) => (
-          <Avatar
-            key={avatar.id}
-            src={avatar.src}
-            alt={avatar.name}
-            size="small"
-          />
-        ))}
-      </AvatarGroup>
-      <AvatarGroup max={3} spacing="small">
-        {AVATARS_GROUP.four.map((avatar) => (
-          <Avatar
-            key={avatar.id}
-            src={avatar.src}
-            alt={avatar.name}
-            size="small"
-          />
-        ))}
-      </AvatarGroup>
+      <AvatarGroup max={3} spacing="small" avatars={AVATARS.slice(0, 2)} />
+      <AvatarGroup max={3} spacing="small" avatars={AVATARS} />
+      <AvatarGroup max={3} spacing="small" avatars={AVATARS_GROUP.double} />
+      <AvatarGroup max={3} spacing="small" avatars={AVATARS_GROUP.triple} />
+      <AvatarGroup max={3} spacing="small" avatars={AVATARS_GROUP.four} />
     </FlexBox>
     <FlexBox sx={{ flexDirection: 'column', gap: 1 }}>
       <Text variant="sectionTitle">Avatar Group - Medium</Text>
-      <AvatarGroup max={3} spacing="small">
-        {AVATARS.slice(0, 2).map((avatar) => (
-          <Avatar key={avatar.id} src={avatar.src} alt={avatar.name} />
-        ))}
-      </AvatarGroup>
-      <AvatarGroup max={3} spacing="small">
-        {AVATARS.map((avatar) => (
-          <Avatar key={avatar.id} src={avatar.src} alt={avatar.name} />
-        ))}
-      </AvatarGroup>
-      <AvatarGroup max={3} spacing="small">
-        {AVATARS_GROUP.double.map((avatar) => (
-          <Avatar key={avatar.id} src={avatar.src} alt={avatar.name} />
-        ))}
-      </AvatarGroup>
-      <AvatarGroup max={3} spacing="small">
-        {AVATARS_GROUP.triple.map((avatar) => (
-          <Avatar key={avatar.id} src={avatar.src} alt={avatar.name} />
-        ))}
-      </AvatarGroup>
-      <AvatarGroup max={3} spacing="small">
-        {AVATARS_GROUP.four.map((avatar) => (
-          <Avatar key={avatar.id} src={avatar.src} alt={avatar.name} />
-        ))}
-      </AvatarGroup>
+      <AvatarGroup
+        max={3}
+        spacing="small"
+        avatars={AVATARS.slice(0, 2)}
+        size="medium"
+      />
+      <AvatarGroup max={3} spacing="small" avatars={AVATARS} size="medium" />
+      <AvatarGroup
+        max={3}
+        spacing="small"
+        avatars={AVATARS_GROUP.double}
+        size="medium"
+      />
+      <AvatarGroup
+        max={3}
+        spacing="small"
+        avatars={AVATARS_GROUP.triple}
+        size="medium"
+      />
+      <AvatarGroup
+        max={3}
+        spacing="small"
+        avatars={AVATARS_GROUP.four}
+        size="medium"
+      />
     </FlexBox>
     <FlexBox sx={{ flexDirection: 'column', gap: 1 }}>
       <Text variant="sectionTitle">Avatar Group - Large</Text>
-      <AvatarGroup max={3} spacing="small">
-        {AVATARS.slice(0, 2).map((avatar) => (
-          <Avatar
-            key={avatar.id}
-            src={avatar.src}
-            alt={avatar.name}
-            size="large"
-          />
-        ))}
-      </AvatarGroup>
-      <AvatarGroup max={3} spacing="small">
-        {AVATARS.map((avatar) => (
-          <Avatar
-            key={avatar.id}
-            src={avatar.src}
-            alt={avatar.name}
-            size="large"
-          />
-        ))}
-      </AvatarGroup>
-      <AvatarGroup max={3} spacing="small">
-        {AVATARS_GROUP.double.map((avatar) => (
-          <Avatar
-            key={avatar.id}
-            src={avatar.src}
-            alt={avatar.name}
-            size="large"
-          />
-        ))}
-      </AvatarGroup>
-      <AvatarGroup max={3} spacing="small">
-        {AVATARS_GROUP.triple.map((avatar) => (
-          <Avatar
-            key={avatar.id}
-            src={avatar.src}
-            alt={avatar.name}
-            size="large"
-          />
-        ))}
-      </AvatarGroup>
-      <AvatarGroup max={3} spacing="small">
-        {AVATARS_GROUP.four.map((avatar) => (
-          <Avatar
-            key={avatar.id}
-            src={avatar.src}
-            alt={avatar.name}
-            size="large"
-          />
-        ))}
-      </AvatarGroup>
+      <AvatarGroup
+        max={3}
+        spacing="small"
+        avatars={AVATARS.slice(0, 2)}
+        size="large"
+      />
+      <AvatarGroup max={3} spacing="small" avatars={AVATARS} size="large" />
+      <AvatarGroup
+        max={3}
+        spacing="small"
+        avatars={AVATARS_GROUP.double}
+        size="large"
+      />
+      <AvatarGroup
+        max={3}
+        spacing="small"
+        avatars={AVATARS_GROUP.triple}
+        size="large"
+      />
+      <AvatarGroup
+        max={3}
+        spacing="small"
+        avatars={AVATARS_GROUP.four}
+        size="large"
+      />
     </FlexBox>
   </>
 );
@@ -200,15 +130,5 @@ export const Default = () => (
 export const Custom: ComponentStory<
   (props: AvatarGroupStoryProps) => JSX.Element
 > = ({ dummyType, size, sx, ...args }) => (
-  <AvatarGroup {...args}>
-    {AVATARS_GROUP[dummyType].map((avatar) => (
-      <Avatar
-        key={avatar.id}
-        src={avatar.src}
-        alt={avatar.name}
-        size={size}
-        sx={sx}
-      />
-    ))}
-  </AvatarGroup>
+  <AvatarGroup {...args} avatars={AVATARS_GROUP[dummyType]} />
 );

--- a/packages/react/src/components/AvatarGroup/avatarGroup.tsx
+++ b/packages/react/src/components/AvatarGroup/avatarGroup.tsx
@@ -1,13 +1,13 @@
-import { Children, cloneElement, ReactElement, ReactNode } from 'react';
 import styled, { useTheme } from 'styled-components';
 
 import Avatar, { AvatarProps } from '@components/Avatar/avatar';
 import FlexBox from '@components/FlexBox/flexBox';
 
 export type AvatarGroupProps = {
-  children: ReactNode;
+  avatars: AvatarProps[];
   max?: number;
   spacing?: 'small' | 'medium' | 'large';
+  size?: 'small' | 'medium' | 'large';
 };
 
 const SPACING_OPTIONS = {
@@ -18,75 +18,46 @@ const SPACING_OPTIONS = {
 
 const MAX_VIEW_COUNT = 999;
 
-const AvatarGroupAvatar = styled(Avatar)<Partial<AvatarGroupProps>>`
+const RestInfoAvatar = styled(Avatar)<Partial<AvatarGroupProps>>`
   border: 2px solid ${({ theme }) => theme.palette.white};
   background-color: ${({ theme }) => theme.palette.neutral_2};
   color: ${({ theme }) => theme.palette.white};
   padding: 2px 3px 0 0;
   margin-left: ${({ spacing }) => spacing && SPACING_OPTIONS[spacing]};
-
   &:first-child {
     margin-left: 0;
   }
 `;
 
 const AvatarGroup = (props: AvatarGroupProps) => {
-  const { children: childrenProp, max = 5, spacing = 'small' } = props;
-  const total = Children.count(childrenProp);
+  const { avatars, size = 'small', max = 5, spacing = 'small' } = props;
   const theme = useTheme();
 
-  // child.props 처럼 props 속성을 사용하기 위해 as 사용
-  const children = Children.toArray(
-    childrenProp,
-  ) as ReactElement<AvatarProps>[];
-
-  if (total > max) {
-    return (
-      <FlexBox>
-        {children.slice(0, max).map((child, index) => {
-          if (index === max - 1) {
-            return (
-              <AvatarGroupAvatar
-                // 변경 가능성 없는 index를 key로 사용
-                // eslint-disable-next-line react/no-array-index-key
-                key={index}
-                spacing={spacing}
-                size={child.props.size}
-              >
-                {`+${
-                  total - max + 1 <= MAX_VIEW_COUNT
-                    ? total - max + 1
-                    : MAX_VIEW_COUNT
-                }`}
-              </AvatarGroupAvatar>
-            );
-          }
-          return cloneElement(child, {
-            // eslint-disable-next-line react/no-array-index-key
-            key: index,
-            sx: {
-              ...child.props.sx,
-              border: `2px solid ${theme.palette.white}`,
-              ...(index === 0 ? {} : { marginLeft: SPACING_OPTIONS[spacing] }),
-            },
-          });
-        })}
-      </FlexBox>
-    );
-  }
+  const total = avatars.length;
+  const isOverMax = total > max;
+  const slicedAvatars = isOverMax ? avatars.slice(0, max - 1) : avatars;
 
   return (
     <FlexBox>
-      {children.map((child, index) =>
-        cloneElement(child, {
+      {slicedAvatars.slice(0, max - 1).map((avatar, index) => (
+        <Avatar
           // eslint-disable-next-line react/no-array-index-key
-          key: index,
-          sx: {
-            ...child.props.sx,
+          key={index}
+          size={size}
+          {...avatar}
+          sx={{
+            ...(avatar.sx ? avatar.sx : {}),
             border: `2px solid ${theme.palette.white}`,
             ...(index === 0 ? {} : { marginLeft: SPACING_OPTIONS[spacing] }),
-          },
-        }),
+          }}
+        />
+      ))}
+      {isOverMax && (
+        <RestInfoAvatar spacing={spacing} size={size}>
+          {`+${
+            total - max + 1 <= MAX_VIEW_COUNT ? total - max + 1 : MAX_VIEW_COUNT
+          }`}
+        </RestInfoAvatar>
       )}
     </FlexBox>
   );

--- a/packages/react/src/components/AvatarGroup/avatarGroup.tsx
+++ b/packages/react/src/components/AvatarGroup/avatarGroup.tsx
@@ -29,6 +29,19 @@ const RestInfoAvatar = styled(Avatar)<Partial<AvatarGroupProps>>`
   }
 `;
 
+/**
+ *
+ * @name AvatarGroup
+ * @description `AvatarGroup` 은 `avatars:AvatarProp[]` 를 prop 으로 전달받아 `Avatar` 컴포넌트 목록을 보여줍니다.
+ * @props `max` : `Avatar` 가 보여질 최대 갯수를 지정합니다. `default: 5`
+ * @props `spacing` : `Avatar` 간의 간격을 `small`, `medium`, `large` 중 선택할 수 있습니다. `default: small`
+ * @props `size` : `small`, `medium`, `large` 중 선택할 수 있습니다. `default: small`
+ * @props `avatars` : Avatar 의 정보를 담는 배열을 입력합니다. ex) AvatarProps[]
+ * @example
+ * ```tsx
+ *  <AvatarGroup max={3} spacing="small" avatars={AVATARS} />
+ * ```
+ */
 const AvatarGroup = (props: AvatarGroupProps) => {
   const { avatars, size = 'small', max = 5, spacing = 'small' } = props;
   const theme = useTheme();


### PR DESCRIPTION
close #60 

이번에 리액트 문서([Children](https://react.dev/reference/react/Children), [cloneElement](https://react.dev/reference/react/cloneElement)) 를 읽어보면서, 제안하고 있는 대체 방법으로 우리의 코드를 개선할 수 있을지 고민해보고, 적용해보았습니다.

> [Children 관련 문서](https://react.dev/reference/react/Children)를 읽으면서, children 으로 인한 문제가 생기지 않겠다는 보장은 어렵다. (사용자가 avatars 를 fragment 로 감싸서 보내준다면, total(Children.count) 이 1개로 적용될 것이고, Children 관련 유틸함수가 제대로 동작하지 않을 것

-> 어차피 Avatar 에 커플링되는 컴포넌트라면 AvatarProp 형태의 객체배열을 받아 사용하는게 낫다고 생각하였고, Children 관련 util 을 모두 제거하고, avatars 를 통해 아바타 관련 객체배열을 전달받아 사용하는 것으로 대체하였습니다.

> cloneElement 를 사용하는 것이 데이터의 흐름(여기선 스타일 관련 props 주입)과 child 의 추적이 어렵다는 단점을 꼽을 수 있겠는데, AvatarGroup 은 Avatar 와 연결되어있다라는 것이 당연한게 아닌가? 라는 생각이라서, child 가 무엇인지 알기 어렵다는 점은 무시할 수 있다고 생각하고, AvatarGroup 을 사용하는 사용자가 굳이 알아야 할 필요도 없는 로직이라고 생각했습니다.

-> 사용자가 Avatar 컴포넌트를 직접 사용하여 넣는방식 대신 AvatarGroup 컴포넌트 내부에서 풀어 사용하면 굳이 cloneElement 를 사용하지 않아도 되겠다고 생각하여 대체하였습니다.

이 외에도 중복된 로직이라고 생각되는 부분을 isOverMax 등의 변수를 활용하여 제거하였습니다.
