### PR TITLE
[Park] noEmit , exclude stories 부분 삭제

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,10 +1,7 @@
 module.exports = {
   '*.{js,jsx,ts,tsx}': 'eslint --fix',
   '*.{js,jsx,ts,tsx,json}': 'prettier --write',
-  'packages/react/**/*.+(ts|tsx)': () =>
-    'tsc -p packages/react/tsconfig.json --noEmit',
-  'packages/playground-react/**/*.+(ts|tsx)': () =>
-    'tsc -p packages/playground-react/tsconfig.json --noEmit',
+  'packages/react/**/*.+(ts|tsx)': () => 'tsc -p packages/react/tsconfig.json',
   'packages/primitives/**/*.+(ts|tsx)': () =>
-    'tsc -p packages/primitives/tsconfig.json --noEmit',
+    'tsc -p packages/primitives/tsconfig.json',
 };

--- a/packages/primitives/tsconfig.json
+++ b/packages/primitives/tsconfig.json
@@ -10,9 +10,9 @@
       "@components/*": ["src/components/*"],
       "@hooks/*": ["src/hooks/*"],
       "@utils/*": ["src/utils/*"],
-      "@styles/*": ["src/styles/*"]
+      "@styles/*": ["src/styles/*"],
+      "@constants/*": ["src/constants/*"]
     }
   },
-  "include": ["src"],
-  "exclude": ["src/**/*.stories.ts*"]
+  "include": ["src"]
 }

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -12,6 +12,5 @@
       "@constants/*": ["src/constants/*"]
     }
   },
-  "include": ["src"],
-  "exclude": ["src/**/*.stories.ts*"]
+  "include": ["src"]
 }


### PR DESCRIPTION
@hemudi 
설정관련 핫픽스로 기록용으로 PR 남기고 바로 merge 하겠습니다

- tsc 시 stories 는 안해도 되지않을까란 생각으로 exclude 했었는데, 개발시 불편함이 더 커서 exclude 부분을 삭제했습니다.
- emitDeclarationOnly 와 noEmit 을 함께 사용하지 말라고 합니다.

husky 에서 type check 를 위해 썼던 옵션이어서 noEmit 부분은 삭제했습니다.

<img width="866" alt="스크린샷 2023-05-03 오후 4 04 10" src="https://user-images.githubusercontent.com/58503584/235851112-660fa8b3-f14d-484f-86b4-5b34f7e223a0.png">
